### PR TITLE
Upgrade OTP and Elixir in github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,15 @@ on: [push, pull_request]
 jobs:
   format:
     name: Format and compile with warnings as errors
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
-          otp-version: 22.1
-          elixir-version: 1.11.2
+          otp-version: 24.0
+          elixir-version: 1.12.2
 
       - name: Check mix format
         run: mix format --check-formatted
@@ -25,13 +25,15 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
         include:
+          - erlang: 24.0
+            elixir: 1.12.2
           - erlang: 23.0
-            elixir: 1.11.2
+            elixir: 1.11.4
           - erlang: 23.0
             elixir: 1.10.4
           - erlang: 22.1
@@ -50,7 +52,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.erlang}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -14,10 +14,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install OTP and Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
-          otp-version: 22.1
-          elixir-version: 1.9.4
+          otp-version: 24.0
+          elixir-version: 1.12.2
 
       - name: Check outdated certdata
         run: |


### PR DESCRIPTION
* Use Elixir 1.12.2 with OTP 24 for format and outdated task.
* Add Elixir 1.12.2 and OTP 24 to test matrix.
* Use `erlef/setup-beam` instead of `erlef/setup-elixir`.
* Upgrade ubuntu to 20.04. The version 16.04 is deprecated and warning
  in the CI. Except only test that is 18.04 because of Elixir 1.4.5.