### PR TITLE
Improve version check for publishing

### DIFF
--- a/.github/workflows/publish.sh
+++ b/.github/workflows/publish.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Assume package name == repository name
+package="${GITHUB_REPOSITORY#*/}"$
+
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
@@ -11,7 +14,7 @@ else
   git push --tags
 fi
 
-if mix hex.info castore "$(cat VERSION)"; then
+if mix hex.info $package "$(cat VERSION)"; then
   echo "NOT PUBLISHING"
 else
   echo "PUBLISHING"

--- a/.github/workflows/publish.sh
+++ b/.github/workflows/publish.sh
@@ -2,15 +2,18 @@
 
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-changed_version="$(git diff --name-only HEAD~1 HEAD -- VERSION)"
 
-if [[ "${changed_version}" ]]; then
-  echo "Publishing because the version changed since the last commit"
-
+if [ $(git tag -l "v$(cat VERSION)") ]; then
+  echo "NOT TAGGING"
+else
+  echo "TAGGING"
   git tag "v$(cat VERSION)"
   git push --tags
+fi
 
-  mix hex.publish --yes
+if mix hex.info castore "$(cat VERSION)"; then
+  echo "NOT PUBLISHING"
 else
-  echo "Not publishing since the version didn't change since last commit"
+  echo "PUBLISHING"
+  mix hex.publish --yes
 fi


### PR DESCRIPTION
The `git diff` check didn't work since actions/checkout only fetches with depth 1. Changed to this check because it feels a bit more robust and we can try publishing when merging this commit without bumping version.